### PR TITLE
feat: first implementation of policy gradient 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/rl.py
+++ b/rl.py
@@ -8,7 +8,6 @@ defined in Figure 2 of the GFlowNet Foundations paper, Bengio et al (JMLR, 2023)
 """
 Key differences with gfn.py:
 - Uses REINFORCE framework instead of GFlowNet training
-- Batches of episodes instead of single episodes to reduce variance
 """
 
 import torch

--- a/rl.py
+++ b/rl.py
@@ -26,7 +26,7 @@ do_print = True
 ### ENVIRONMENT ###
 
 discount_factor = 1.0 # No discounting
-batch_size = 32
+batch_size = 1
 
 # A dictionary of connections: the keys of the dictionary are the indices of the
 # states, and the values are the indices of the states to which each state is
@@ -78,7 +78,8 @@ policy = Policy(n_states, float_type, device)
 
 n_train_steps = 2000
 learning_rate = 0.01
-optimizer = torch.optim.Adam(policy.parameters(), lr=learning_rate)
+momentum = 0.9
+optimizer = torch.optim.SGD(policy.parameters(), lr=learning_rate, momentum=momentum)
 
 ### LOSS FUNCTION ###
 


### PR DESCRIPTION
I experimented with solving the toy environment using policy gradient RL instead of GFlowNets. The goal was to keep it as minimal and close to the original GFlowNet implementation as possible. If there is any error or improvement, feel free to let me know!

Key differences:
- Uses policy gradient for training instead of GFlowNet.
- Runs batches of episodes (instead of single episodes) to reduce variance.

Results:
- As expected, the evaluation metric (MAE) is higher than with GFlowNets, since RL optimizes for maximizing reward rather than yielding samples proportional to reward.

Next steps:
- With Thursday’s quiz looming, any possibility of salvaging participation points will be taken. 
- I’d also be open to implementing this environment in JAX for the remaining points!